### PR TITLE
fix goroutine leak on limit/interval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,9 @@ language: go
 go:
     - 1.12.x
 
+env:
+    global:
+        - GO111MODULE=on
+
 script:
     - go test -v -race $( go list -f="{{if or .TestGoFiles .XTestGoFiles }}{{.ImportPath}}{{end}}" ./...)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+go:
+    - 1.12.x
+
+script:
+    - go test -v -race $( go list -f="{{if or .TestGoFiles .XTestGoFiles }}{{.ImportPath}}{{end}}" ./...)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Package transport provides the HTTP transport utilities.
 
-[![Codeship](https://img.shields.io/codeship/cd1b13a0-e9b6-0133-f67a-4afac8d396b8.svg?maxAge=60)](https://codeship.com/projects/147664)
+[![Build Status](https://travis-ci.org/wacul/transport.svg?branch=master)](https://travis-ci.org/wacul/transport)
 
 ## USAGE
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/wacul/transport
+
+go 1.12
+
+require golang.org/x/net v0.0.0-20191021144547-ec77196f6094

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20191021144547-ec77196f6094 h1:5O4U9trLjNpuhpynaDsqwCk+Tw6seqJz1EbqbnzHrc8=
+golang.org/x/net v0.0.0-20191021144547-ec77196f6094/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/limit/concurrent.go
+++ b/limit/concurrent.go
@@ -45,7 +45,7 @@ func NewMaxConcurrentTransport(concurrent int) *RateLimit {
 }
 
 func getConcurrentStarter(num int) channelStarter {
-	return func(closeCh chan struct{}, _expireCh chan struct{}) *priorityChannel {
+	return func(closeCh chan struct{}, _expireCh chan<- struct{}) *priorityChannel {
 		block := make(chan struct{}, num)
 		pc := initPriorityChannel(closeCh)
 		go func() {

--- a/limit/concurrent.go
+++ b/limit/concurrent.go
@@ -45,7 +45,7 @@ func NewMaxConcurrentTransport(concurrent int) *RateLimit {
 }
 
 func getConcurrentStarter(num int) channelStarter {
-	return func(closeCh chan struct{}, _expireCh chan<- struct{}) *priorityChannel {
+	return func(closeCh chan struct{}) *priorityChannel {
 		block := make(chan struct{}, num)
 		pc := initPriorityChannel(closeCh)
 		go func() {

--- a/limit/concurrent.go
+++ b/limit/concurrent.go
@@ -45,7 +45,7 @@ func NewMaxConcurrentTransport(concurrent int) *RateLimit {
 }
 
 func getConcurrentStarter(num int) channelStarter {
-	return func(closeCh chan struct{}) *priorityChannel {
+	return func(closeCh chan struct{}, _expireCh chan struct{}) *priorityChannel {
 		block := make(chan struct{}, num)
 		pc := initPriorityChannel(closeCh)
 		go func() {

--- a/limit/concurrent_test.go
+++ b/limit/concurrent_test.go
@@ -2,14 +2,11 @@ package limit
 
 import (
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
-)
-
-import (
-	"net/http"
-	"net/http/httptest"
 )
 
 type concurrentTest struct {

--- a/limit/interval.go
+++ b/limit/interval.go
@@ -9,7 +9,6 @@ import (
 // that cooperate with the each of themselves to limit intervals of the requests
 type IntervalTransportFactory struct {
 	Interval   time.Duration
-	Expire     *time.Duration
 	closeCh    chan struct{}
 	channelMap map[string]*priorityChannel
 	ml         *sync.Mutex
@@ -33,7 +32,6 @@ func (f *IntervalTransportFactory) init() {
 func (f *IntervalTransportFactory) NewTransport() *RateLimit {
 	f.initOnce.Do(f.init)
 	return &RateLimit{
-		Expire:         f.Expire,
 		channelStarter: getIntervalStarter(f.Interval),
 		closeCh:        f.closeCh,
 		channelMap:     f.channelMap,

--- a/limit/interval.go
+++ b/limit/interval.go
@@ -49,7 +49,7 @@ func NewIntervalTransport(interval time.Duration, expire *time.Duration) *RateLi
 }
 
 func getIntervalStarter(interval time.Duration, expire *time.Duration) channelStarter {
-	return func(closeCh chan struct{}, expireCh chan struct{}) *priorityChannel {
+	return func(closeCh chan struct{}, expireCh chan<- struct{}) *priorityChannel {
 		pc := initPriorityChannel(closeCh)
 		tick := time.Tick(interval)
 

--- a/limit/interval_test.go
+++ b/limit/interval_test.go
@@ -95,7 +95,7 @@ func TestIntervalWithExpire(t *testing.T) {
 	transport := NewIntervalTransport(exInterval)
 	transport.GroupKeyFunc = GroupKeyByHost
 	expire := 10 * time.Millisecond
-	transport.Expire = &expire
+	transport.ExpireCheckInterval = &expire
 	defer transport.Close()
 
 	testClient := &http.Client{

--- a/limit/interval_test.go
+++ b/limit/interval_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 type intervalTest struct {
@@ -85,16 +87,41 @@ func TestIntervalFactory(t *testing.T) {
 	}
 }
 
+const groupKey = "x-key"
+
+func groupKeyByHeader(r *http.Request) string {
+	return r.Header.Get(groupKey)
+}
+
+type intervalMultiTest struct {
+	lastRequested map[string]time.Time
+	intervals     map[string][]time.Duration
+	l             sync.Mutex
+}
+
+func (it *intervalMultiTest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rt := time.Now()
+
+	it.l.Lock()
+	key := r.Header.Get(groupKey)
+	it.intervals[key] = append(it.intervals[key], rt.Sub(it.lastRequested[key]))
+	it.lastRequested[key] = rt
+	it.l.Unlock()
+}
+
 func TestIntervalWithExpire(t *testing.T) {
-	it := &intervalTest{}
+	it := &intervalMultiTest{
+		lastRequested: make(map[string]time.Time),
+		intervals:     make(map[string][]time.Duration),
+	}
 	s := httptest.NewServer(it)
 	defer s.Close()
 
 	exInterval := 100 * time.Millisecond
 
 	transport := NewIntervalTransport(exInterval)
-	transport.GroupKeyFunc = GroupKeyByHost
-	expire := 10 * time.Millisecond
+	transport.GroupKeyFunc = groupKeyByHeader
+	expire := 300 * time.Millisecond
 	transport.ExpireCheckInterval = &expire
 	defer transport.Close()
 
@@ -102,34 +129,56 @@ func TestIntervalWithExpire(t *testing.T) {
 		Transport: transport,
 	}
 
-	wg := sync.WaitGroup{}
-	numReq := 10
-	wg.Add(numReq)
-	for i := 0; i < numReq; i++ {
-		time.Sleep(20 * time.Millisecond)
+	request := func(wg *sync.WaitGroup, key string) {
+		req, err := http.NewRequest("GET", s.URL, nil)
+		require.NoError(t, err)
+		req.Header.Set(groupKey, key)
 		go func() {
-			testClient.Get(s.URL)
+			testClient.Do(req)
 			wg.Done()
 		}()
 	}
-	wg.Wait()
 
-	if it.minInterval < exInterval-(10*time.Millisecond) { // handler may delay
-		t.Errorf("min request interval to server must grater than %s actual %s", exInterval.String(), it.minInterval.String())
-	}
+	numReq := 10
+	keys := []string{"a", "b", "c"}
 
-	time.Sleep(20 * time.Millisecond)
-
+	// first
 	{
 		wg := sync.WaitGroup{}
-		numReq := 10
-		wg.Add(numReq)
 		for i := 0; i < numReq; i++ {
-			go func() {
-				testClient.Get(s.URL)
-				wg.Done()
-			}()
+			wg.Add(len(keys))
+			for _, key := range keys {
+				request(&wg, key)
+			}
 		}
 		wg.Wait()
+	}
+
+	// waiting expire
+	time.Sleep(300 * time.Millisecond)
+
+	// second(create new channel after expire)
+	{
+		wg := sync.WaitGroup{}
+		for i := 0; i < numReq; i++ {
+			wg.Add(len(keys))
+			for _, key := range keys {
+				request(&wg, key)
+			}
+		}
+		wg.Wait()
+	}
+
+	// assert all request intervals
+	assertInterval := func(key string) {
+		limit := exInterval - (10 * time.Millisecond) // handler may delay
+		for _, interval := range it.intervals[key] {
+			if interval < limit {
+				t.Errorf("min request interval to server must grater than %s actual %s", exInterval.String(), interval.String())
+			}
+		}
+	}
+	for _, key := range keys {
+		assertInterval(key)
 	}
 }

--- a/limit/interval_test.go
+++ b/limit/interval_test.go
@@ -30,8 +30,7 @@ func TestInterval(t *testing.T) {
 
 	exInterval := 100 * time.Millisecond
 
-	var expire *time.Duration
-	transport := NewIntervalTransport(exInterval, expire)
+	transport := NewIntervalTransport(exInterval)
 	transport.GroupKeyFunc = GroupKeyByHost
 	defer transport.Close()
 
@@ -93,9 +92,10 @@ func TestIntervalWithExpire(t *testing.T) {
 
 	exInterval := 100 * time.Millisecond
 
-	expire := 10 * time.Millisecond
-	transport := NewIntervalTransport(exInterval, &expire)
+	transport := NewIntervalTransport(exInterval)
 	transport.GroupKeyFunc = GroupKeyByHost
+	expire := 10 * time.Millisecond
+	transport.Expire = &expire
 	defer transport.Close()
 
 	testClient := &http.Client{

--- a/limit/priority_channel.go
+++ b/limit/priority_channel.go
@@ -6,26 +6,33 @@ import (
 
 // priorityChannel is the channels support the priority of them.
 type priorityChannel struct {
-	Out    chan interface{}
-	High   chan interface{}
-	Normal chan interface{}
-	Low    chan interface{}
+	Out     chan interface{}
+	High    chan interface{}
+	Normal  chan interface{}
+	Low     chan interface{}
+	closeCh chan struct{}
 
 	refCount uint
 	mu       *sync.Mutex
 }
 
 // initPriorityChannel will create the priorityChannel and initialize it
-func initPriorityChannel(closeCh <-chan struct{}) *priorityChannel {
+func initPriorityChannel() *priorityChannel {
 	pc := priorityChannel{}
 	pc.Out = make(chan interface{})
 	pc.High = make(chan interface{})
 	pc.Normal = make(chan interface{})
 	pc.Low = make(chan interface{})
+	pc.closeCh = make(chan struct{})
 	pc.mu = new(sync.Mutex)
 
-	pc.start(closeCh)
+	pc.start()
 	return &pc
+}
+
+// Close :
+func (pc *priorityChannel) Close() {
+	close(pc.closeCh)
 }
 
 func (pc *priorityChannel) add() {
@@ -46,13 +53,13 @@ func (pc *priorityChannel) using() bool {
 	return pc.refCount != 0
 }
 
-func (pc *priorityChannel) start(closeCh <-chan struct{}) {
+func (pc *priorityChannel) start() {
 	go func() {
 		for {
 			select {
 			case s := <-pc.High:
 				pc.Out <- s
-			case <-closeCh:
+			case <-pc.closeCh:
 				return
 			default:
 			}
@@ -62,7 +69,7 @@ func (pc *priorityChannel) start(closeCh <-chan struct{}) {
 				pc.Out <- s
 			case s := <-pc.Normal:
 				pc.Out <- s
-			case <-closeCh:
+			case <-pc.closeCh:
 				return
 			default:
 			}
@@ -74,7 +81,7 @@ func (pc *priorityChannel) start(closeCh <-chan struct{}) {
 				pc.Out <- s
 			case s := <-pc.Low:
 				pc.Out <- s
-			case <-closeCh:
+			case <-pc.closeCh:
 				return
 			}
 		}

--- a/limit/priority_channel.go
+++ b/limit/priority_channel.go
@@ -49,7 +49,7 @@ func (pc *priorityChannel) done() {
 }
 
 // if true, this cannot stop safely.
-func (pc *priorityChannel) using() bool {
+func (pc *priorityChannel) hasConsumer() bool {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 	return pc.refCount != 0

--- a/limit/priority_channel.go
+++ b/limit/priority_channel.go
@@ -1,5 +1,9 @@
 package limit
 
+import (
+	"sync"
+)
+
 // priorityChannel is the channels support the priority of them.
 type priorityChannel struct {
 	Out    chan interface{}
@@ -7,6 +11,9 @@ type priorityChannel struct {
 	Normal chan interface{}
 	Low    chan interface{}
 	stopCh chan struct{}
+
+	refCount uint
+	mu       *sync.Mutex
 }
 
 // initPriorityChannel will create the priorityChannel and initialize it
@@ -17,6 +24,7 @@ func initPriorityChannel(closeCh <-chan struct{}) *priorityChannel {
 	pc.Normal = make(chan interface{})
 	pc.Low = make(chan interface{})
 	pc.stopCh = make(chan struct{})
+	pc.mu = new(sync.Mutex)
 
 	pc.start()
 	return &pc
@@ -25,10 +33,24 @@ func initPriorityChannel(closeCh <-chan struct{}) *priorityChannel {
 // Close will close all channels in it.
 func (pc *priorityChannel) Close() {
 	close(pc.stopCh)
-	close(pc.High)
-	close(pc.Normal)
-	close(pc.Low)
-	close(pc.Out)
+}
+
+func (pc *priorityChannel) add() {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	pc.refCount++
+}
+
+func (pc *priorityChannel) done() {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	pc.refCount--
+}
+
+func (pc *priorityChannel) using() bool {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	return pc.refCount != 0
 }
 
 func (pc *priorityChannel) start() {

--- a/limit/priority_channel.go
+++ b/limit/priority_channel.go
@@ -35,18 +35,21 @@ func (pc *priorityChannel) Close() {
 	close(pc.closeCh)
 }
 
+// increment the reference count like sync.WaitGroup
 func (pc *priorityChannel) add() {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 	pc.refCount++
 }
 
+// decrement the reference count like sync.WaitGroup
 func (pc *priorityChannel) done() {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 	pc.refCount--
 }
 
+// if true, this cannot stop safely.
 func (pc *priorityChannel) using() bool {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()

--- a/limit/priority_channel.go
+++ b/limit/priority_channel.go
@@ -13,7 +13,7 @@ type priorityChannel struct {
 	closeCh chan struct{}
 
 	refCount uint
-	mu       *sync.Mutex
+	mu       sync.Mutex
 }
 
 // initPriorityChannel will create the priorityChannel and initialize it
@@ -24,7 +24,6 @@ func initPriorityChannel() *priorityChannel {
 	pc.Normal = make(chan interface{})
 	pc.Low = make(chan interface{})
 	pc.closeCh = make(chan struct{})
-	pc.mu = new(sync.Mutex)
 
 	pc.start()
 	return &pc

--- a/limit/rate_limit_base.go
+++ b/limit/rate_limit_base.go
@@ -32,6 +32,9 @@ type RateLimit struct {
 	channelMap          map[string]*priorityChannel
 	ml                  *sync.Mutex
 	initOnce            sync.Once
+
+	// for testing
+	onChannelFinished func(key string)
 }
 
 // ConstantGroupKeyFunc restricts whole requests in RateLimit
@@ -101,6 +104,9 @@ func (t *RateLimit) tryExpire(ch *priorityChannel, key string) bool {
 	}
 	delete(t.channelMap, key)
 	ch.Close()
+	if t.onChannelFinished != nil {
+		t.onChannelFinished(key)
+	}
 	return true
 }
 

--- a/limit/rate_limit_base.go
+++ b/limit/rate_limit_base.go
@@ -96,7 +96,6 @@ func (t *RateLimit) expire(ch *priorityChannel, key string) bool {
 		return false
 	}
 	delete(t.channelMap, key)
-	ch.Close()
 	t.closeCh <- struct{}{}
 	return true
 }

--- a/limit/rate_limit_base.go
+++ b/limit/rate_limit_base.go
@@ -175,9 +175,4 @@ func (t *RateLimit) Close() {
 	if t.closeCh != nil {
 		close(t.closeCh)
 	}
-	t.ml.Lock()
-	defer t.ml.Unlock()
-	for _, ch := range t.channelMap {
-		ch.Close()
-	}
 }

--- a/limit/rate_limit_base.go
+++ b/limit/rate_limit_base.go
@@ -17,7 +17,7 @@ type requestPayload struct {
 	resCh     chan *httpResponseResult
 }
 
-type channelStarter func(chan struct{}, chan struct{}) *priorityChannel
+type channelStarter func(chan struct{}, chan<- struct{}) *priorityChannel
 
 // RateLimit is an implementation of the RoundTripper
 // that limits a quantity of requests in the groups

--- a/limit/rate_limit_base.go
+++ b/limit/rate_limit_base.go
@@ -96,7 +96,7 @@ func (t *RateLimit) waitCh(key string) *priorityChannel {
 func (t *RateLimit) tryExpire(ch *priorityChannel, key string) bool {
 	t.ml.Lock()
 	defer t.ml.Unlock()
-	if ch.using() {
+	if ch.hasConsumer() {
 		return false
 	}
 	delete(t.channelMap, key)

--- a/limit/rate_limit_base.go
+++ b/limit/rate_limit_base.go
@@ -70,8 +70,8 @@ func (t *RateLimit) waitCh(key string) *priorityChannel {
 		return ch
 	}
 	ch = t.channelStarter(t.closeCh)
-	t.channelMap[key] = ch
 	ch.add()
+	t.channelMap[key] = ch
 
 	go func() {
 		for {
@@ -81,7 +81,7 @@ func (t *RateLimit) waitCh(key string) *priorityChannel {
 			case <-after(t.Expire):
 			}
 			if t.expire(ch, key) {
-				break
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
## Current behavior
`RateLimit` without `ConstantGroupKeyFunc` makes goroutine leak.

## Expected behavior
There is no goroutine leak.

## Todo
- [x] impl
- [x] add ci
- [x] go mod init && go mod tidy
- [x] add test codes
